### PR TITLE
Migrate to Python 3.14 and raise HA floor to 2026.6.4

### DIFF
--- a/.github/workflows/multi-arch.yml
+++ b/.github/workflows/multi-arch.yml
@@ -43,5 +43,5 @@ jobs:
       - name: Import shapely on ${{ matrix.platform }}
         run: |
           docker run --rm --platform=${{ matrix.platform }} \
-            -v "$PWD:/src" -w /src python:3.13-slim \
+            -v "$PWD:/src" -w /src python:3.14-slim \
             bash -euxc 'pip install --quiet "shapely>=2.0,<3" && python tests/smoke/shapely_smoke.py'

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -30,10 +30,10 @@ jobs:
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install Home Assistant + runtime deps
-        run: pip install "homeassistant>=2026.1,<2027" "shapely>=2.0,<3"
+        run: pip install "homeassistant>=2026.6.4,<2027" "shapely>=2.0,<3"
 
       - name: Stage HA config dir with the integration installed
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: pip
           cache-dependency-path: requirements_test.txt
       - run: pip install -r requirements_test.txt
@@ -74,11 +74,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: pip
           cache-dependency-path: requirements_test.txt
       - run: pip install -r requirements_test.txt
-      - run: pip install "homeassistant==2026.1.*"
+      - run: pip install "homeassistant==2026.6.4"
       - run: pytest --cov=custom_components/polygonal_zones --cov-report=term --cov-fail-under=98
 
   mypy:
@@ -88,7 +88,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: pip
           cache-dependency-path: requirements_test.txt
       - run: pip install -r requirements_test.txt

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ files = ["custom_components/polygonal_zones"]
 
 [tool.ruff]
 line-length = 100
-target-version = "py312"
+target-version = "py314"
 
 [tool.ruff.lint]
 select = [

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -2,7 +2,7 @@
 # floor doesn't silently green-on-break when HA core ships an API change.
 # Upper bound allows patch bumps within the same minor. Dependabot (see
 # .github/dependabot.yml) bumps weekly.
-homeassistant>=2026.1,<2027
+homeassistant>=2026.6.4,<2027
 mypy
 pytest
 pytest-asyncio


### PR DESCRIPTION
## Why
HA `2026.3.0`+ requires **Python >=3.14.2**, which capped this project at HA `2026.2.x` on the Python 3.13 toolchain and blocked #7. This moves CI to Python 3.14 and raises the tested HA floor to `2026.6.4`.

## Changes
- `validate.yml`: Pytest, Pytest (HA floor), Mypy → Python 3.14; floor pin `2026.1.*` → `2026.6.4`
- `playwright.yml`: Python 3.14; HA install `>=2026.6.4`
- `multi-arch.yml`: shapely smoke image `python:3.13-slim` → `3.14-slim`
- `requirements_test.txt`: `homeassistant>=2026.6.4,<2027`
- `pyproject.toml`: ruff `target-version` `py312` → `py314`

No integration code changes were required.

## Verified locally (Python 3.14.6 + HA 2026.6.4)
- ruff check + format: clean (py314 target valid)
- pytest: **250 passed, 98.61% coverage**
- mypy: clean
- shapely 2.1.2 installs via cp314 wheel (no source build)

## Supersedes
Closes #7 (its `requirements_test.txt` floor bump is included here).