### PR TITLE
Docs site: fork notice, custom-repo install guide, privacy notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 [![License: MIT](https://img.shields.io/github/license/MatthewHobbs/Homeassistant-polygonal-zones)](LICENSE)
 [![Maintenance](https://img.shields.io/maintenance/yes/2026)](https://github.com/MatthewHobbs/Homeassistant-polygonal-zones/commits/main)
 
+**Full documentation (install guide, zone format reference, privacy notice):** [matthewhobbs.github.io/Homeassistant-polygonal-zones](https://matthewhobbs.github.io/Homeassistant-polygonal-zones)
+
 This Home Assistant integration lets you define arbitrary polygonal zones from a GeoJSON file and resolve any tracked `device_tracker` entity into the zone it currently sits inside. Use it when the built-in circular HA zones aren't expressive enough — irregular property boundaries, school catchments, neighbourhoods, town centres, etc.
 
 **Status:** stable (v1.9.0). Actively maintained; HACS-ready. Manifest declares `quality_scale: bronze`; the rules for Silver, Gold, and Platinum are implemented and tracked in [`quality_scale.yaml`](custom_components/polygonal_zones/quality_scale.yaml), but a higher tier can only be claimed after a Home Assistant architecture-team review (which happens through the [core-integration submission process](https://developers.home-assistant.io/docs/creating_component_index/), not by self-declaration).
@@ -21,6 +23,7 @@ This Home Assistant integration lets you define arbitrary polygonal zones from a
 
 ## Contents
 
+- [Companion add-on](#companion-add-on)
 - [Installation](#installation)
 - [First-time setup](#first-time-setup)
 - [Configuration options](#configuration-options)
@@ -36,6 +39,12 @@ This Home Assistant integration lets you define arbitrary polygonal zones from a
 - [Roadmap](#roadmap)
 - [Contributing](#contributing)
 - [License](#license)
+
+## Companion add-on
+
+This integration is one half of a paired system. The other half is the **[Polygonal Zones Editor add-on](https://github.com/MatthewHobbs/Homeassistant-polygonal-zones-addon)** — a map editor that runs inside Home Assistant where you draw zones and save them. It serves the `zones.json` file this integration reads.
+
+If you're setting up for the first time, install the add-on first: it gives you a URL (`http://<your-ha-host>:8000/zones.json`) to paste into the integration's `zone_urls` field. See the [full install guide](https://matthewhobbs.github.io/Homeassistant-polygonal-zones/install/) for a step-by-step walkthrough of both.
 
 ## Installation
 

--- a/docs/ZONES_FORMAT.md
+++ b/docs/ZONES_FORMAT.md
@@ -1,3 +1,10 @@
+---
+layout: page
+title: Zone File Format
+nav_order: 3
+permalink: /zones-format/
+---
+
 # Polygonal Zones file format
 
 This document is the canonical specification for the GeoJSON file consumed by the `polygonal_zones` Home Assistant integration. Producers of zone files (the companion [editor add-on](https://github.com/MatthewHobbs/Homeassistant-polygonal-zones-addon), third-party tools, or hand-written files) MUST follow this spec; the integration parses against it.

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,24 @@
+title: "Polygonal Zones for Home Assistant"
+description: "Community-maintained integration and add-on for polygon-based location tracking in Home Assistant."
+
+theme: minima
+
+url: "https://matthewhobbs.github.io"
+baseurl: "/Homeassistant-polygonal-zones"
+
+header_pages:
+  - index.md
+  - install.md
+  - ZONES_FORMAT.md
+  - troubleshooting.md
+  - privacy.md
+
+minima:
+  date_format: "%Y-%m-%d"
+
+markdown: kramdown
+kramdown:
+  input: GFM
+
+plugins:
+  - jekyll-seo-tag

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,36 @@
+---
+layout: page
+title: Home
+nav_order: 1
+permalink: /
+---
+
+# Polygonal Zones for Home Assistant
+
+Polygonal Zones lets you define irregular, polygon-shaped zones in Home Assistant and track `device_tracker` entities against them. Where HA's built-in circular zones don't fit — an oddly shaped property, a school catchment, a neighbourhood boundary — you draw the actual shape and get an entity whose state is simply the zone name (e.g. `Home`, `School`, `Park`) or `away`.
+
+> **Fork Notice**
+>
+> Polygonal Zones is a community-maintained continuation of the original [MichelGerding/Homeassistant-polygonal-zones](https://github.com/MichelGerding/Homeassistant-polygonal-zones) and [MichelGerding/Homeassistant-polygonal-zones-addon](https://github.com/MichelGerding/Homeassistant-polygonal-zones-addon), both of which are no longer actively maintained. Development continues here, run as a spare-time community project.
+>
+> Integration: [MatthewHobbs/Homeassistant-polygonal-zones](https://github.com/MatthewHobbs/Homeassistant-polygonal-zones)
+>
+> Add-on: [MatthewHobbs/Homeassistant-polygonal-zones-addon](https://github.com/MatthewHobbs/Homeassistant-polygonal-zones-addon)
+
+## Two paired components
+
+This project is made up of two pieces that work together:
+
+**Add-on — Polygonal Zones Editor**
+A Home Assistant add-on (FastAPI + Leaflet map) where you draw zones on a map, name them, and hit Save. It stores your zones as a `zones.json` file and serves it over HTTP at `http://<your-ha-host>:8000/zones.json`.
+
+**Integration — Polygonal Zones**
+A HACS custom integration (pure Python) that watches `device_tracker` entities and resolves each one against your polygon zones. It reads the `zones.json` produced by the add-on and creates a mirror entity (`device_tracker.polygonal_zones_<name>`) whose state is whichever zone the device is currently inside, or `away`.
+
+The typical setup is: install the add-on to draw your zones, then point the integration at the add-on's `zones.json` URL.
+
+---
+
+[Install both components &rarr;](install.md){: .btn }
+&nbsp;&nbsp;
+[Zone file format reference &rarr;](zones-format.md){: .btn }

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,141 @@
+---
+layout: page
+title: Installation
+nav_order: 2
+permalink: /install/
+---
+
+# Installation
+
+Install the **add-on first**, then the **integration**. The add-on draws your zones and serves `zones.json`; the integration reads that file. You need both.
+
+**Requirements:** Home Assistant 2026.6.4 or later, Python 3.14 (bundled with HA OS — no action needed if you run HA OS or Supervised).
+
+---
+
+## Step 1 — Add-on: Polygonal Zones Editor
+
+The add-on is a map editor that runs inside Home Assistant. You draw polygons on a map, name them, and save. The result is a `zones.json` file the integration consumes.
+
+### 1a. Add the custom repository
+
+Click the button to add the add-on repository to your Home Assistant Supervisor:
+
+[![Add add-on repository to Home Assistant](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2FMatthewHobbs%2FHomeassistant-polygonal-zones-addon.git)
+
+If the button doesn't work, add it manually:
+
+1. **Settings → Add-ons → Add-on Store**
+2. Click **⋮** (top right) → **Repositories**
+3. Paste `https://github.com/MatthewHobbs/Homeassistant-polygonal-zones-addon` and click **Add**
+
+### 1b. Install the add-on
+
+After adding the repository, find **Polygonal Zones** in the Add-on Store and click **Install**.
+
+> **32-bit hosts.** HA 2025.12 deprecated `armhf`, `armv7`, and `i386` addon architectures. Add-on releases from 0.2.26 onwards are `aarch64` and `amd64` only. If you're on a 32-bit host (Raspberry Pi 0/1, 32-bit OS), pin to add-on version 0.2.25 or upgrade to a 64-bit HA OS install.
+
+### 1c. Start the add-on and draw your zones
+
+1. Go to **Settings → Add-ons → Polygonal Zones** and click **Start**.
+2. Click **Open Web UI** to open the map editor.
+3. Click the pentagon (Draw Polygon) button on the right side of the map.
+4. Click points on the map to define your zone's shape, then click the first point again to close it.
+5. Give the zone a name in the sidebar.
+6. Click **Save** (bottom of the sidebar). Unsaved changes are lost on restart.
+
+Repeat for each zone you want to define.
+
+### 1d. Note the zones.json URL
+
+The add-on serves your zones at:
+
+```
+http://<your-ha-host>:8000/zones.json
+```
+
+You'll need this URL when you configure the integration in Step 2. You can also enable **Show in sidebar** on the add-on's Configuration tab to keep the editor one click away.
+
+---
+
+## Step 2 — Integration: Polygonal Zones
+
+The integration is a HACS custom integration that watches `device_tracker` entities and resolves their GPS position against your polygon zones.
+
+### 2a. Add via HACS
+
+[![Add to HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=MatthewHobbs&repository=Homeassistant-polygonal-zones&category=integration)
+
+If the button doesn't work, add it manually in HACS:
+
+1. Open **HACS** in the sidebar
+2. Click **⋮** (top right) → **Custom repositories**
+3. Paste `https://github.com/MatthewHobbs/Homeassistant-polygonal-zones` and set category to **Integration**
+4. Click **Add**, then find **Polygonal Zones** in HACS and click **Download**
+
+### 2b. Restart Home Assistant
+
+After downloading the integration, restart Home Assistant (**Settings → System → Restart**) before proceeding.
+
+### 2c. Add the integration
+
+[![Add Polygonal Zones integration](https://my.home-assistant.io/badges/config_flow_start.svg)](https://my.home-assistant.io/redirect/config_flow_start/?domain=polygonal_zones)
+
+Or navigate manually: **Settings → Devices & Services → Add Integration** → search for **Polygonal Zones**.
+
+### 2d. Configure the integration
+
+Fill in the setup form:
+
+| Field                              | What to enter                                                                               |
+| ---------------------------------- | ------------------------------------------------------------------------------------------- |
+| **URLs of GeoJSON files**          | `http://<your-ha-host>:8000/zones.json` — the add-on URL from Step 1d.                      |
+| **Entities**                       | The `device_tracker.*` entities you want to track against your zones.                       |
+| **Prioritize order of zone files** | _(advanced)_ When a position matches zones from multiple files, prefer the earlier file.    |
+| **Download the GeoJSON files**     | _(advanced)_ Copies the remote file locally so you can mutate zones via automation actions. |
+
+> **LAN URL note.** The integration's SSRF defence blocks private network addresses (`192.168.x.x`, `10.x.x.x`, etc.) by default. Because the add-on URL is a LAN address, you need to enable **Allow private-network URLs (LAN)** in the integration's advanced options. This unlocks RFC-1918 space; loopback, link-local, and metadata ranges stay blocked regardless.
+>
+> In the add-on, also make sure `allow_all_ips: true` is set under **Settings → Add-ons → Polygonal Zones → Configuration** so the integration's requests are accepted.
+
+Click **Submit**. The integration creates one new entity per tracked device:
+
+```
+device_tracker.alice_phone  →  device_tracker.polygonal_zones_alice_phone
+```
+
+### 2e. Verify
+
+Open **Developer Tools → States** and look for `device_tracker.polygonal_zones_*`. The state should be a zone name or `away` within a few seconds of the source device reporting a GPS fix.
+
+If the entity stays `unknown` for more than a minute, see [Troubleshooting](troubleshooting.md).
+
+---
+
+## What you'll have when done
+
+- A map editor (add-on) reachable from your HA sidebar or via **Open Web UI**
+- A `zones.json` served at `http://<ha-host>:8000/zones.json`
+- One `device_tracker.polygonal_zones_<name>` entity per tracked device, with state = zone name or `away`
+- Automation triggers like "notify me when Alice arrives at School"
+
+Use the mirror entity's state directly in automations:
+
+```yaml
+automation:
+  - alias: "Notify when Alice arrives at school"
+    triggers:
+      - trigger: state
+        entity_id: device_tracker.polygonal_zones_alice_phone
+        to: "School"
+    actions:
+      - action: notify.mobile_app
+        data:
+          message: "Alice has arrived at school"
+```
+
+---
+
+## Privacy note
+
+The integration continuously processes real GPS coordinates of the `device_tracker` entities you select. New installs default `Expose GPS coordinates` to **off** — only the zone name is published to entity attributes. However, the recorder still logs state-change timestamps unless you exclude the entities. See [Privacy](privacy.md) for the full picture, including how to exclude entities from the recorder and how to handle deletion requests.

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,0 +1,103 @@
+---
+layout: page
+title: Privacy
+nav_order: 4
+permalink: /privacy/
+---
+
+# Privacy and data handling
+
+This page covers what data the integration and add-on process, where it goes, and what you can do to limit retention. It is written for people running this at home, not as a legal compliance document.
+
+---
+
+## Integration: what it processes
+
+The integration continuously monitors the GPS position of every `device_tracker` entity you select during setup. That includes real-time latitude, longitude, and GPS accuracy from each tracked device.
+
+**Everything runs locally inside your Home Assistant instance.** The integration itself does not send any data to third parties, analytics services, or the project maintainers.
+
+### What is stored and where
+
+| Data                              | Where it goes                                                                                                              |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| Resolved zone name                | Entity state (`device_tracker.polygonal_zones_<name>`)                                                                     |
+| Latitude, longitude, GPS accuracy | Entity attributes — only if **Expose GPS coordinates** is enabled                                                          |
+| Zone history                      | Home Assistant's recorder database (HA's `home-assistant_v2.db`)                                                           |
+| Downloaded zone file              | `<config>/polygonal_zones/<entry_id>.json` (mode 0600, directory 0700) — only if **Download the GeoJSON files** is enabled |
+| GPS coordinates in logs           | Only at `DEBUG` log level — never written at default (`INFO`) level                                                        |
+
+### Expose GPS coordinates
+
+This option controls whether latitude, longitude, and GPS accuracy are written to entity attributes on each update.
+
+- **New installs** default this to **off** — only the zone name is published.
+- **Existing installs** that were created before this option was added keep their old default of **on**, for backwards compatibility. If you upgraded from an earlier version, check your setting under **Settings → Devices & Services → Polygonal Zones → Configure → Advanced options**.
+
+When `Expose GPS coordinates` is **on**, Home Assistant's recorder accumulates a full location history for every tracked person in its SQLite database (including backups). To disable coordinate exposure, re-open the integration's Configure dialog and un-tick the option.
+
+### Recorder history
+
+Even with coordinates off, the recorder logs state-change timestamps (when a person enters or leaves a zone) unless you explicitly exclude the entities. To stop the recorder from accumulating any history for the mirror entities, add this to your `configuration.yaml`:
+
+```yaml
+recorder:
+  exclude:
+    entity_globs:
+      - device_tracker.polygonal_zones_*
+```
+
+Restart Home Assistant after adding it.
+
+### Tracking other people
+
+Any person whose `device_tracker` entity you select will have their location continuously monitored. If that includes people other than yourself — household members, children — please make sure they are aware and have agreed to it before you add their device.
+
+### Outbound requests
+
+When `zone_urls` points at an `http(s)://` URL, the integration fetches it from your HA instance. The server hosting the GeoJSON file will see your HA instance's outbound IP address. Private, loopback, and link-local addresses are blocked by default to prevent SSRF; enabling **Allow private-network URLs (LAN)** relaxes this only for RFC-1918 space.
+
+### Logging
+
+GPS coordinates and zone names are only logged at `DEBUG` level. At default log settings they are never written to the HA log. `WARNING`-level log lines (raised when a zone file can't be fetched) include the source `entity_id` (e.g. `device_tracker.alice_phone`) — if you forward HA logs to an external aggregator, consider redacting those lines.
+
+---
+
+## Add-on: map tiles and zone file
+
+### Third-party map tiles
+
+The add-on's map editor loads map tiles from third-party servers. Depending on which tile layer is active, that may include:
+
+- **OpenStreetMap** (operated by the OpenStreetMap Foundation)
+- **CARTO** (operated by Carto, Inc.)
+- **Esri** (operated by Esri)
+
+Each tile request reveals your approximate map viewport (lat/lon bounding box) and your IP address to the tile provider. No zone geometry is sent — only the map viewport you're looking at. If you're zoomed in on a precise home address while drawing zones, the tile provider can infer that area of interest from the viewport.
+
+This is the same data exposure as any web map (Google Maps, Apple Maps, etc.). The tile providers operate under their own privacy policies.
+
+### zones.json is location PII
+
+Your `zones.json` file contains the precise polygon coordinates of every place you've drawn — your home boundary, workplace, school run, and so on. Treat it accordingly:
+
+- **HA backups and snapshots include it.** The zones file lives in `/data` inside the add-on container, which is captured in every HA backup. Deleting a zone from the editor does not remove it from snapshots taken before the deletion. If you need to fully remove a zone for privacy reasons, also delete the old backups that contain it (**Settings → System → Backups → ⋮ → Remove**).
+- **Do not host zones.json on a public URL.** See the [DOCS.md](https://github.com/MatthewHobbs/Homeassistant-polygonal-zones-addon/blob/main/polygonal_zones_editor/DOCS.md) section "Last resort — public-CDN mirror" for the full explanation of why this is a privacy risk.
+- **Cloud backups.** If you use Nabu Casa cloud backup and the recorder database is included (the default), the location history of every tracked person is transferred to Nabu Casa's US-hosted infrastructure. Under GDPR Art. 46, this is a cross-border transfer of personal data. Either apply the `recorder` exclude block above before enabling cloud backup, or review Nabu Casa's data-processing terms.
+
+---
+
+## Responding to a deletion request
+
+If a tracked person asks for their location data to be removed:
+
+1. **Remove the entity from the integration.** Settings → Devices & Services → Polygonal Zones → Configure → untick their entity → Save. The mirror entity is deleted automatically.
+2. **Purge recorder history.** Developer Tools → Actions → `recorder.purge_entities`:
+   ```yaml
+   entity_id:
+     - device_tracker.polygonal_zones_<original>
+     - device_tracker.<original>
+   ```
+   With `keep_days: 0` (the default), this removes all past state rows immediately.
+3. **Delete any downloaded zone file.** If **Download the GeoJSON files** was enabled for this entry, remove `<config>/polygonal_zones/<entry_id>.json`.
+4. **Rotate backups.** Any HA backup taken before these steps still contains the history. Delete old backups if full erasure is required, or rely on the backup's own retention expiry.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,103 @@
+---
+layout: page
+title: Troubleshooting
+nav_order: 5
+permalink: /troubleshooting/
+---
+
+# Troubleshooting
+
+Covers the most common problems with the integration. For add-on issues, check the add-on log first: **Settings → Add-ons → Polygonal Zones → Log**.
+
+Integration source: [MatthewHobbs/Homeassistant-polygonal-zones](https://github.com/MatthewHobbs/Homeassistant-polygonal-zones)
+Add-on source: [MatthewHobbs/Homeassistant-polygonal-zones-addon](https://github.com/MatthewHobbs/Homeassistant-polygonal-zones-addon)
+
+---
+
+## The mirror entity stays `unknown` or `away`
+
+- Check that the source `device_tracker.*` entity actually has `latitude`, `longitude`, and `gps_accuracy` attributes. Many Wi-Fi-only trackers don't provide GPS coordinates — they report presence but not position. The integration needs all three attributes to evaluate zone membership.
+- Look in the HA log for messages tagged `custom_components.polygonal_zones`. A `WARNING` line saying "Failed to load zones for entry=…" means the GeoJSON couldn't be fetched on startup. The integration retries with exponential backoff (30 s, 60 s, 120 s, 240 s, 480 s, five attempts) before giving up and raising a HA repair issue. After the source recovers, call `polygonal_zones.reload_zones` to force a retry.
+- Confirm the polygon ring is closed: the first coordinate must equal the last coordinate.
+- Confirm the geometry type is `Polygon` or `MultiPolygon`. `Point`, `LineString`, and other types are rejected.
+
+---
+
+## Config-flow errors
+
+| Banner            | Meaning                                                                                                                                     |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `invalid_url`     | One of the entries isn't a valid `http(s)` URL. Check the protocol and that the host is present.                                            |
+| `invalid_path`    | A non-URL entry doesn't resolve to an existing file inside `/config`, or it tries to escape the config directory (e.g. `../../etc/passwd`). |
+| `unreachable_url` | The URL passed validation but couldn't be fetched at setup time.                                                                            |
+
+---
+
+## "Refusing to connect to non-public address"
+
+The integration won't fetch from `127.0.0.1`, `192.168.x.x`, `10.x.x.x`, `169.254.x.x`, or any other private, loopback, link-local, or metadata IP by default. This prevents SSRF.
+
+If your zones file is served from a LAN address (including the companion add-on on the same host), you have two options:
+
+- **Enable `allow_private_urls`.** Re-open the integration's Configure dialog, expand Advanced options, and tick **Allow private-network URLs (LAN)**. This unlocks RFC-1918 space; loopback, link-local, and metadata ranges stay blocked.
+- **Use a `/config` path instead.** Place the `zones.json` file under your HA config directory and reference it as a path (e.g. `polygonal_zones/zones.json`). No network request is made.
+
+---
+
+## `ZoneFileNotEditable` from a service call
+
+The mutating actions (`add_new_zone`, `edit_zone`, `delete_zone`, `replace_all_zones`) only work when **Download the GeoJSON files** is enabled in the integration options. Without it, the integration reads the source URL directly on every reload and has no local file to mutate.
+
+To fix: re-open Configure → enable **Download the GeoJSON files** → save.
+
+---
+
+## `Path '…' resolves outside config directory`
+
+A path you supplied in `zone_urls` (or via a service call) escapes `/config` when normalised. Fix the path so it stays within the HA config directory.
+
+---
+
+## `Timed out waiting for lock on …`
+
+A previous service call against the same zone file didn't complete within 15 seconds. Usually transient — retry the action. If it recurs, check for very slow remote fetches or filesystem issues.
+
+---
+
+## The add-on's map won't load / tiles are broken
+
+The add-on loads map tiles from third-party providers (OpenStreetMap, CARTO, Esri). If tiles fail to render, check:
+
+- Your HA instance has outbound internet access.
+- A browser console error identifies which tile provider is failing and why.
+- If tiles worked before and broke after an upgrade, check the add-on [CHANGELOG](https://github.com/MatthewHobbs/Homeassistant-polygonal-zones-addon/blob/main/polygonal_zones_editor/CHANGELOG.md) for tile-layer changes.
+
+---
+
+## Increasing log verbosity
+
+Set the integration's logger to `DEBUG` to see GPS coordinates, zone resolution results, and full lifecycle events:
+
+```yaml
+logger:
+  default: info
+  logs:
+    custom_components.polygonal_zones: debug
+```
+
+Add this to `configuration.yaml` and restart HA. GPS coordinates and zone names are only emitted at `DEBUG` level — see [Privacy](privacy.md) before shipping logs to an external service.
+
+For the add-on, set `log_level: debug` under **Settings → Add-ons → Polygonal Zones → Configuration** and restart the add-on.
+
+---
+
+## Opening an issue
+
+If the above doesn't resolve your problem, open an issue with:
+
+- HA version and integration version (shown in HACS or **Settings → Devices & Services → Polygonal Zones**)
+- The relevant log lines from `custom_components.polygonal_zones` (at `DEBUG` level if possible — but redact any personal coordinates before pasting)
+- Whether you're using the add-on or a self-hosted `zones.json`
+
+Integration issues: [github.com/MatthewHobbs/Homeassistant-polygonal-zones/issues](https://github.com/MatthewHobbs/Homeassistant-polygonal-zones/issues)
+Add-on issues: [github.com/MatthewHobbs/Homeassistant-polygonal-zones-addon/issues](https://github.com/MatthewHobbs/Homeassistant-polygonal-zones-addon/issues)


### PR DESCRIPTION
Implements panel P0 #3 (docs/GitHub Pages reflecting the fork + abandoned upstream + install-via-custom-repo).

## New Pages site (`docs/`, Jekyll/minima)
- **index.md** — landing + prominent fork notice (both upstreams abandoned) + paired-component explainer + CTAs
- **install.md** — sequenced custom-repo install: add-on repo first, then HACS custom repo; `my.home-assistant.io` badges; `allow_private_urls` LAN pairing; HA 2026.6.4 / Python 3.14 floor
- **privacy.md** — GPS scope, `expose_coordinates` upgrade default + recorder purge, third-party tile egress (OSM/CARTO/Esri), zones.json as location PII (from the DPO review)
- **troubleshooting.md** — adapted from README
- **ZONES_FORMAT.md** — front matter added; remains the single source of truth (renders at `/zones-format/`)

## README
Pages link + an early companion-add-on pointer (so readers learn about the paired add-on up front).

## To enable Pages after merge
Settings → Pages → Deploy from branch → `main` → `/docs`.

## Caveats
- Not yet rendered/built locally; `_config.yml` `baseurl` assumes the default `matthewhobbs.github.io/Homeassistant-polygonal-zones` path; nav uses `nav_order` while theme is `minima` (uses `header_pages`) — worth a check when Pages is turned on.
- Authored by the technical-writer agent. Docs-only change.