### PR TITLE
Fix MultiPolygon crash in zone tie-break + reload echo

### DIFF
--- a/custom_components/polygonal_zones/device_tracker.py
+++ b/custom_components/polygonal_zones/device_tracker.py
@@ -29,6 +29,7 @@ from .const import (
     DOMAIN,
 )
 from .utils import event_should_trigger, get_locations_zone
+from .utils.geometry import exterior_coords
 from .utils.local_zones import download_zones
 from .utils.zones import Zone, ZoneFileCorrupt, load_zones
 
@@ -423,7 +424,7 @@ class PolygonalZoneEntity(TrackerEntity, RestoreEntity):
                 {
                     "name": z.name,
                     "priority": z.priority,
-                    "geometry": list(z.geometry.exterior.coords),
+                    "geometry": list(exterior_coords(z.geometry)),
                 }
                 for z in self._zones
             ]

--- a/custom_components/polygonal_zones/utils/geometry.py
+++ b/custom_components/polygonal_zones/utils/geometry.py
@@ -12,10 +12,26 @@ from __future__ import annotations
 from collections.abc import Iterable
 import math
 
-from shapely.geometry import Point
+from shapely.geometry import MultiPolygon, Point
 from shapely.geometry.polygon import Polygon
 
 _EARTH_RADIUS_M = 6371000
+
+
+def exterior_coords(geometry: Polygon | MultiPolygon) -> Iterable[tuple[float, float]]:
+    """Yield exterior-ring coordinates of a Polygon or every part of a MultiPolygon.
+
+    The GeoJSON spec and the editor add-on both allow ``MultiPolygon`` zones, so
+    callers must not assume ``geometry.exterior`` exists (``MultiPolygon`` has no
+    ``.exterior`` — only ``.geoms``). Interior rings (holes) are intentionally
+    ignored: distance-to-zone is measured to the outer boundary only, matching
+    the prior Polygon-only behaviour.
+    """
+    if isinstance(geometry, MultiPolygon):
+        for part in geometry.geoms:
+            yield from part.exterior.coords
+    else:
+        yield from geometry.exterior.coords
 
 
 def _haversine_metres(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
@@ -46,17 +62,24 @@ def haversine_distances(
     return [_haversine_metres(lat1, lon1, lat2, lon2) for lat2, lon2 in coordinates]
 
 
-def get_distance_to_exterior_points(polygon: Polygon, point: Point) -> float:
-    """Haversine distance to the closest point on the polygon's exterior, in metres.
+def get_distance_to_exterior_points(polygon: Polygon | MultiPolygon, point: Point) -> float:
+    """Haversine distance to the closest point on the zone's exterior, in metres.
+
+    Accepts ``Polygon`` and ``MultiPolygon`` (the latter previously raised
+    ``AttributeError`` here, crashing zone tie-breaking).
 
     Uses ``(point.x, point.y)`` directly (which in shapely terms is ``(lon, lat)``
     for GeoJSON-convention polygons) to preserve the exact numerics of the prior
     numpy implementation.
     """
-    return min(_haversine_metres(point.x, point.y, x, y) for x, y in polygon.exterior.coords)
+    return min(_haversine_metres(point.x, point.y, x, y) for x, y in exterior_coords(polygon))
 
 
-def get_distance_to_centroid(polygon: Polygon, point: Point) -> float:
-    """Haversine distance from ``point`` to the polygon's centroid, in metres (JSON-safe)."""
+def get_distance_to_centroid(polygon: Polygon | MultiPolygon, point: Point) -> float:
+    """Haversine distance from ``point`` to the zone's centroid, in metres (JSON-safe).
+
+    ``.centroid`` is defined for ``MultiPolygon`` too, so no special-casing is
+    needed here.
+    """
     centroid = polygon.centroid
     return _haversine_metres(point.x, point.y, centroid.x, centroid.y)

--- a/tests/test_geometry_multipolygon.py
+++ b/tests/test_geometry_multipolygon.py
@@ -1,0 +1,49 @@
+"""Regression tests: geometry helpers must handle MultiPolygon zones.
+
+The editor add-on and the GeoJSON spec both allow ``MultiPolygon`` geometries.
+``get_distance_to_exterior_points`` previously did ``polygon.exterior.coords``,
+which raises ``AttributeError`` on a ``MultiPolygon`` and crashed zone
+tie-breaking the moment two same-priority zones overlapped and one was a
+multi-part zone.
+"""
+
+from shapely.geometry import MultiPolygon, Point, Polygon
+
+from custom_components.polygonal_zones.utils.geometry import (
+    exterior_coords,
+    get_distance_to_centroid,
+    get_distance_to_exterior_points,
+)
+
+# Two disjoint unit squares → a MultiPolygon.
+_SQUARE_A = Polygon([(0, 0), (0, 1), (1, 1), (1, 0)])
+_SQUARE_B = Polygon([(5, 5), (5, 6), (6, 6), (6, 5)])
+_MULTI = MultiPolygon([_SQUARE_A, _SQUARE_B])
+
+
+def test_exterior_coords_polygon():
+    coords = list(exterior_coords(_SQUARE_A))
+    assert (0.0, 0.0) in coords
+    assert len(coords) == 5  # closed ring repeats the first vertex
+
+
+def test_exterior_coords_multipolygon_covers_all_parts():
+    coords = list(exterior_coords(_MULTI))
+    # Vertices from both parts must be present.
+    assert (0.0, 0.0) in coords
+    assert (5.0, 5.0) in coords
+    assert len(coords) == 10  # two closed 5-point rings
+
+
+def test_distance_to_exterior_points_multipolygon_does_not_raise():
+    point = Point(0.5, 0.5)  # inside square A
+    dist = get_distance_to_exterior_points(_MULTI, point)
+    # Closest exterior point of the nearer part; finite, non-negative metres.
+    assert dist >= 0.0
+    # Must equal the single-Polygon answer for the nearer part (B is far away).
+    assert dist == get_distance_to_exterior_points(_SQUARE_A, point)
+
+
+def test_distance_to_centroid_multipolygon_does_not_raise():
+    point = Point(0.5, 0.5)
+    assert get_distance_to_centroid(_MULTI, point) >= 0.0


### PR DESCRIPTION
Panel P0 (data-engineer / lead-backend): `get_distance_to_exterior_points` called `polygon.exterior.coords`, which raises `AttributeError` on a `MultiPolygon`.

## Impact
The URI loader builds geometries via `shape()` with **no type restriction** (`zones.py:112`), and the add-on + GeoJSON spec both allow `MultiPolygon`. So a user with a multi-part zone hits a crash in:
- zone **tie-break** (`zones.py:260`) when two same-priority zones overlap, and
- the **reload-response** geometry echo (`device_tracker.py:426`).

## Fix
- `geometry.py`: new `exterior_coords()` that iterates a `Polygon`'s ring or every part of a `MultiPolygon`; used by `get_distance_to_exterior_points`; type hints widened. `get_distance_to_centroid` already works for `MultiPolygon` (`.centroid` is defined).
- `device_tracker.py`: reload echo uses `exterior_coords()`.
- Regression tests added.

Interior rings (holes) remain ignored — distance is to the outer boundary, matching prior Polygon behaviour.

## Verified (Python 3.14.6 + HA 2026.6.4)
254 pass · 98.62% coverage · mypy + ruff clean. Dual-reviewed (Claude + codex), no findings.

> Note: the **haversine lat/lon argument order** (`geometry.py`) flagged alongside this by the panel is **left unchanged** — the docstring deliberately preserves prior numpy numerics; changing it alters user-visible distances/tie-breaks and is a separate maintainer decision (see synthesis).