### PR TITLE
Harden zone loader: FeatureCollection check, fetch sub-timeouts, known id key

### DIFF
--- a/custom_components/polygonal_zones/services/helpers.py
+++ b/custom_components/polygonal_zones/services/helpers.py
@@ -26,7 +26,10 @@ SUPPORTED_GEOMETRY_TYPES = {"Polygon", "MultiPolygon"}
 # Declared top-level feature property keys. Anything else is preserved through
 # round-trip but logged at WARNING so drift is visible. New producer-specific
 # fields belong under ``properties.polygonal_zones_ext``. See docs/ZONES_FORMAT.md.
-KNOWN_FEATURE_PROPERTY_KEYS = frozenset({"name", "priority", "polygonal_zones_ext"})
+# ``id`` is the editor add-on's stable per-feature handle (uuid4 hex) used to
+# bind automations across renames — it appears on every add-on-produced file,
+# so it is a known key, not drift (otherwise every mutation logs a WARNING).
+KNOWN_FEATURE_PROPERTY_KEYS = frozenset({"name", "priority", "id", "polygonal_zones_ext"})
 
 # Minimum seconds between mutation-service calls for a single config entry.
 # A low-privilege authenticated user can't wedge the event loop by spamming

--- a/custom_components/polygonal_zones/utils/general.py
+++ b/custom_components/polygonal_zones/utils/general.py
@@ -13,7 +13,11 @@ from homeassistant.core import Event, HomeAssistant, State
 _LOGGER = logging.getLogger(__name__)
 
 MAX_RESPONSE_BYTES = 5 * 1024 * 1024
-FETCH_TIMEOUT = aiohttp.ClientTimeout(total=10)
+# Sub-timeouts as well as the overall budget: a slow TLS handshake or a
+# server that dribbles the body must not consume the whole 10s window and
+# starve the retry budget. connect caps the handshake; sock_read caps any
+# single read stall.
+FETCH_TIMEOUT = aiohttp.ClientTimeout(total=10, connect=5, sock_read=8)
 
 
 def safe_config_path(config_dir: str, user_path: str) -> Path:

--- a/custom_components/polygonal_zones/utils/zones.py
+++ b/custom_components/polygonal_zones/utils/zones.py
@@ -138,6 +138,12 @@ async def _load_zones_from_uri(
     if not isinstance(data, dict):
         raise ZoneFileCorrupt("top-level payload is not an object")
 
+    # Be at least as strict as the mutation-service validator, which rejects a
+    # non-FeatureCollection. Without this, a payload missing the type member
+    # (e.g. ``{"features": [...]}``) was silently accepted on the load path.
+    if data.get("type") != "FeatureCollection":
+        raise ZoneFileCorrupt("top-level 'type' must be 'FeatureCollection'")
+
     pz = data.get("polygonal_zones")
     if isinstance(pz, dict):
         declared_version = pz.get("schema_version", 1)

--- a/tests/test_loader_hardening.py
+++ b/tests/test_loader_hardening.py
@@ -1,0 +1,61 @@
+"""Regression tests for loader/reliability hardening.
+
+- The URI loader must reject a payload that is not a GeoJSON FeatureCollection,
+  matching the strictness of the mutation-service validator.
+- The HTTP fetch timeout must carry connect/read sub-timeouts, not just a total.
+- ``id`` (the editor add-on's stable per-feature handle) must be a known
+  feature property key so add-on-produced files don't log a WARNING on every
+  mutation.
+"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from custom_components.polygonal_zones.services.helpers import KNOWN_FEATURE_PROPERTY_KEYS
+from custom_components.polygonal_zones.utils.general import FETCH_TIMEOUT
+from custom_components.polygonal_zones.utils.zones import ZoneFileCorrupt, get_zones
+
+_FEATURE = {
+    "type": "Feature",
+    "properties": {"name": "Home"},
+    "geometry": {"type": "Polygon", "coordinates": [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]]},
+}
+
+
+async def test_loader_rejects_non_feature_collection() -> None:
+    """A payload missing the FeatureCollection type member is not loaded."""
+    payload = json.dumps({"features": [_FEATURE]})  # no "type"
+    with (
+        patch(
+            "custom_components.polygonal_zones.utils.zones.load_data",
+            new=AsyncMock(return_value=payload),
+        ),
+        pytest.raises(ZoneFileCorrupt),
+    ):
+        # Single URI; it fails the type check, so all URIs failed -> raises.
+        await get_zones(["http://example.com/zones.json"], SimpleNamespace(), False)
+
+
+async def test_loader_accepts_valid_feature_collection() -> None:
+    payload = json.dumps({"type": "FeatureCollection", "features": [_FEATURE]})
+    with patch(
+        "custom_components.polygonal_zones.utils.zones.load_data",
+        new=AsyncMock(return_value=payload),
+    ):
+        zones = await get_zones(["http://example.com/zones.json"], SimpleNamespace(), False)
+    assert [z.name for z in zones] == ["Home"]
+
+
+def test_fetch_timeout_has_sub_timeouts() -> None:
+    assert FETCH_TIMEOUT.total == 10
+    assert FETCH_TIMEOUT.connect == 5
+    assert FETCH_TIMEOUT.sock_read == 8
+
+
+def test_id_is_a_known_feature_property_key() -> None:
+    # The add-on stamps properties.id on every feature; it must not be treated
+    # as drift (which would WARN on every mutation service call).
+    assert "id" in KNOWN_FEATURE_PROPERTY_KEYS


### PR DESCRIPTION
Three panel P1 hardening items (integration), batched.

## Changes
- **`zones.py`** (data-engineer): the URI loader now rejects a payload that isn't a `FeatureCollection` — previously `{"features": [...]}` without the `type` member was silently accepted on the load path, while the mutation-service validator rejected it. Asymmetry closed.
- **`general.py`** (sre): `FETCH_TIMEOUT` gains `connect=5` + `sock_read=8` alongside `total=10`, so a slow TLS handshake or a server dribbling the body can't eat the whole window and starve the retry budget.
- **`services/helpers.py`** (data-engineer): add `id` to `KNOWN_FEATURE_PROPERTY_KEYS`. The editor add-on stamps `properties.id` on every feature, so without this every mutation service call logged a WARNING ("unknown property") for add-on-produced files.

## Verified (Python 3.14.6 + HA 2026.6.4)
258 pass · 98.62% coverage · mypy + ruff clean. New regression tests in `tests/test_loader_hardening.py`. Dual-reviewed (Claude + codex), no findings.