### PR TITLE
Offload zone parsing to executor + read-time caps

### DIFF
--- a/custom_components/polygonal_zones/services/helpers.py
+++ b/custom_components/polygonal_zones/services/helpers.py
@@ -11,17 +11,19 @@ from homeassistant.helpers import device_registry as dr
 
 from ..const import DOMAIN
 from ..device_tracker import PolygonalZoneEntity
+from ..utils.limits import (
+    MAX_FEATURES_PER_COLLECTION,
+    MAX_TOTAL_VERTICES_PER_COLLECTION,
+)
+from ..utils.limits import (
+    count_geometry_vertices as _count_geometry_vertices,
+)
 from .errors import InvalidZoneData, RateLimited
 
 _LOGGER = logging.getLogger(__name__)
 
 MAX_ZONE_JSON_BYTES = 1_048_576
 MAX_ZONE_NAME_LEN = 200
-MAX_FEATURES_PER_COLLECTION = 500
-# Total vertex count across every ring of every polygon in the collection.
-# Caps event-loop stall time inside shapely.buffer()/.intersects() on each
-# state_changed — a 1 MiB JSON file can otherwise encode ~50k vertices.
-MAX_TOTAL_VERTICES_PER_COLLECTION = 10_000
 SUPPORTED_GEOMETRY_TYPES = {"Polygon", "MultiPolygon"}
 # Declared top-level feature property keys. Anything else is preserved through
 # round-trip but logged at WARNING so drift is visible. New producer-specific
@@ -80,29 +82,6 @@ def audit_mutation_call(call: ServiceCall, service_name: str, entry_id: str) -> 
         user_id or "<automation/system>",
         entry_id,
     )
-
-
-def _count_geometry_vertices(geometry: dict) -> int:
-    """Sum the vertex count across every ring of a Polygon / MultiPolygon.
-
-    Walks the ``coordinates`` tree instead of calling into shapely so the cap
-    can be enforced before geometry construction, which is the expensive step
-    we are trying to keep off the event loop.
-    """
-    coordinates = geometry.get("coordinates")
-    if not isinstance(coordinates, list):
-        return 0
-
-    polygons = [coordinates] if geometry.get("type") == "Polygon" else coordinates
-
-    total = 0
-    for polygon in polygons:
-        if not isinstance(polygon, list):
-            continue
-        for ring in polygon:
-            if isinstance(ring, list):
-                total += len(ring)
-    return total
 
 
 def _validate_feature(feature: object) -> None:

--- a/custom_components/polygonal_zones/utils/limits.py
+++ b/custom_components/polygonal_zones/utils/limits.py
@@ -1,0 +1,38 @@
+"""Shared size limits for zone collections.
+
+Single source of truth for the caps enforced on BOTH the mutation-service
+write path (``services/helpers.py``) and the URI/file read path
+(``utils/zones.py``). Kept in ``utils`` so both layers can import it without a
+``utils`` -> ``services`` dependency.
+"""
+
+from __future__ import annotations
+
+MAX_FEATURES_PER_COLLECTION = 500
+# Total vertex count across every ring of every polygon in the collection.
+# Caps event-loop stall time inside shapely.buffer()/.intersects() on each
+# state_changed — a 1 MiB JSON file can otherwise encode ~50k vertices.
+MAX_TOTAL_VERTICES_PER_COLLECTION = 10_000
+
+
+def count_geometry_vertices(geometry: dict) -> int:
+    """Sum the vertex count across every ring of a Polygon / MultiPolygon.
+
+    Walks the ``coordinates`` tree instead of calling into shapely so the cap
+    can be enforced before geometry construction, which is the expensive step
+    we are trying to keep off the event loop.
+    """
+    coordinates = geometry.get("coordinates")
+    if not isinstance(coordinates, list):
+        return 0
+
+    polygons = [coordinates] if geometry.get("type") == "Polygon" else coordinates
+
+    total = 0
+    for polygon in polygons:
+        if not isinstance(polygon, list):
+            continue
+        for ring in polygon:
+            if isinstance(ring, list):
+                total += len(ring)
+    return total

--- a/custom_components/polygonal_zones/utils/zones.py
+++ b/custom_components/polygonal_zones/utils/zones.py
@@ -19,6 +19,11 @@ from .geometry import (
     get_distance_to_exterior_points,
     haversine_distances,
 )
+from .limits import (
+    MAX_FEATURES_PER_COLLECTION,
+    MAX_TOTAL_VERTICES_PER_COLLECTION,
+    count_geometry_vertices,
+)
 
 # Re-exported for back-compat with call sites / tests that imported from zones.
 __all__ = [
@@ -121,16 +126,14 @@ def _parse_feature(feature: Any, default_priority: int) -> Zone:
     )
 
 
-async def _load_zones_from_uri(
-    uri: str,
-    idx: int,
-    prioritize: bool,
-    hass: HomeAssistant,
-    *,
-    allow_private_urls: bool = False,
-) -> list[Zone]:
-    """Load and parse one zone file. Returns a list of zones or raises a typed error."""
-    raw = await load_data(uri, hass, allow_private_urls=allow_private_urls)
+def _parse_zone_document(raw: str, idx: int, prioritize: bool, uri: str) -> list[Zone]:
+    """Parse + validate one zone document into ``Zone`` objects (CPU-only).
+
+    Runs in an executor (see :func:`_load_zones_from_uri`): ``json.loads`` on a
+    multi-MiB file and shapely geometry construction for up to
+    ``MAX_TOTAL_VERTICES_PER_COLLECTION`` vertices can each take tens to hundreds
+    of milliseconds, which must not block the event loop on every reload.
+    """
     try:
         data = json.loads(raw)
     except ValueError as err:
@@ -158,8 +161,43 @@ async def _load_zones_from_uri(
     if not isinstance(features, list):
         raise ZoneFileCorrupt("'features' is missing or not a list")
 
+    # Read-time caps. A remote/file producer is not bound by the mutation
+    # service's validator, so enforce the same bounds here — otherwise a large
+    # (or adversarial) zones.json makes every state_changed event run shapely
+    # over an unbounded vertex set on the event loop.
+    if len(features) > MAX_FEATURES_PER_COLLECTION:
+        raise ZoneFileCorrupt(
+            f"zone file has {len(features)} features; limit is {MAX_FEATURES_PER_COLLECTION}"
+        )
+    total_vertices = sum(
+        count_geometry_vertices(feature["geometry"])
+        for feature in features
+        if isinstance(feature, dict) and isinstance(feature.get("geometry"), dict)
+    )
+    if total_vertices > MAX_TOTAL_VERTICES_PER_COLLECTION:
+        raise ZoneFileCorrupt(
+            f"zone file has {total_vertices} vertices; limit is {MAX_TOTAL_VERTICES_PER_COLLECTION}"
+        )
+
     default_priority = idx if prioritize else 0
     return [_parse_feature(feature, default_priority) for feature in features]
+
+
+async def _load_zones_from_uri(
+    uri: str,
+    idx: int,
+    prioritize: bool,
+    hass: HomeAssistant,
+    *,
+    allow_private_urls: bool = False,
+) -> list[Zone]:
+    """Fetch one zone file and parse it off the event loop.
+
+    The network fetch stays on the loop; the CPU-heavy parse (``json.loads`` +
+    shapely construction) is offloaded to the executor.
+    """
+    raw = await load_data(uri, hass, allow_private_urls=allow_private_urls)
+    return await hass.async_add_executor_job(_parse_zone_document, raw, idx, prioritize, uri)
 
 
 async def load_zones(

--- a/tests/test_loader_hardening.py
+++ b/tests/test_loader_hardening.py
@@ -18,6 +18,15 @@ from custom_components.polygonal_zones.services.helpers import KNOWN_FEATURE_PRO
 from custom_components.polygonal_zones.utils.general import FETCH_TIMEOUT
 from custom_components.polygonal_zones.utils.zones import ZoneFileCorrupt, get_zones
 
+
+async def _run_executor_job(func, *args):
+    return func(*args)
+
+
+def _make_hass() -> SimpleNamespace:
+    return SimpleNamespace(async_add_executor_job=_run_executor_job)
+
+
 _FEATURE = {
     "type": "Feature",
     "properties": {"name": "Home"},
@@ -36,7 +45,7 @@ async def test_loader_rejects_non_feature_collection() -> None:
         pytest.raises(ZoneFileCorrupt),
     ):
         # Single URI; it fails the type check, so all URIs failed -> raises.
-        await get_zones(["http://example.com/zones.json"], SimpleNamespace(), False)
+        await get_zones(["http://example.com/zones.json"], _make_hass(), False)
 
 
 async def test_loader_accepts_valid_feature_collection() -> None:
@@ -45,8 +54,25 @@ async def test_loader_accepts_valid_feature_collection() -> None:
         "custom_components.polygonal_zones.utils.zones.load_data",
         new=AsyncMock(return_value=payload),
     ):
-        zones = await get_zones(["http://example.com/zones.json"], SimpleNamespace(), False)
+        zones = await get_zones(["http://example.com/zones.json"], _make_hass(), False)
     assert [z.name for z in zones] == ["Home"]
+
+
+async def test_loader_rejects_too_many_features() -> None:
+    """Read-time cap: a file exceeding the feature limit is rejected, not parsed."""
+    from custom_components.polygonal_zones.utils.limits import MAX_FEATURES_PER_COLLECTION
+
+    payload = json.dumps(
+        {"type": "FeatureCollection", "features": [_FEATURE] * (MAX_FEATURES_PER_COLLECTION + 1)}
+    )
+    with (
+        patch(
+            "custom_components.polygonal_zones.utils.zones.load_data",
+            new=AsyncMock(return_value=payload),
+        ),
+        pytest.raises(ZoneFileCorrupt),
+    ):
+        await get_zones(["http://example.com/zones.json"], _make_hass(), False)
 
 
 def test_fetch_timeout_has_sub_timeouts() -> None:

--- a/tests/test_zones_loader.py
+++ b/tests/test_zones_loader.py
@@ -19,6 +19,16 @@ from custom_components.polygonal_zones.utils.zones import (
 )
 
 
+async def _run_executor_job(func, *args):
+    """Inline stand-in for hass.async_add_executor_job (runs the func directly)."""
+    return func(*args)
+
+
+def _make_hass() -> SimpleNamespace:
+    """Minimal hass stub: the loader offloads parsing via async_add_executor_job."""
+    return SimpleNamespace(async_add_executor_job=_run_executor_job)
+
+
 def _polygon(name: str, priority: int | None = None) -> dict:
     feature = {
         "type": "Feature",
@@ -45,7 +55,7 @@ async def test_get_zones_parses_feature_collection() -> None:
         "custom_components.polygonal_zones.utils.zones.load_data",
         new=AsyncMock(return_value=payload),
     ):
-        zones = await get_zones(["http://example.com/zones.json"], SimpleNamespace(), False)
+        zones = await get_zones(["http://example.com/zones.json"], _make_hass(), False)
 
     assert len(zones) == 2
     assert {z.name for z in zones} == {"Home", "Work"}
@@ -67,7 +77,7 @@ async def test_get_zones_prioritise_uses_file_index() -> None:
     ):
         zones = await get_zones(
             ["http://example.com/a.json", "http://example.com/b.json"],
-            SimpleNamespace(),
+            _make_hass(),
             True,
         )
 
@@ -117,7 +127,7 @@ async def test_prioritize_file_index_resolves_overlapping_point_to_file_0() -> N
     ):
         zones = await get_zones(
             ["http://example.com/primary.json", "http://example.com/backup.json"],
-            SimpleNamespace(),
+            _make_hass(),
             True,
         )
 
@@ -163,7 +173,7 @@ def test_get_zones_empty_uri_list_returns_empty_list() -> None:
     """Edge case: zero URIs → empty list, not a crash."""
 
     async def _go():
-        return await get_zones([], SimpleNamespace(), False)
+        return await get_zones([], _make_hass(), False)
 
     zones = asyncio.run(_go())
     assert zones == []
@@ -176,7 +186,7 @@ async def test_get_zones_accepts_missing_schema_version() -> None:
         "custom_components.polygonal_zones.utils.zones.load_data",
         new=AsyncMock(return_value=payload),
     ):
-        zones = await get_zones(["http://x"], SimpleNamespace(), False)
+        zones = await get_zones(["http://x"], _make_hass(), False)
     assert zones[0].name == "Home"
 
 
@@ -192,7 +202,7 @@ async def test_get_zones_accepts_known_schema_version() -> None:
         "custom_components.polygonal_zones.utils.zones.load_data",
         new=AsyncMock(return_value=payload),
     ):
-        zones = await get_zones(["http://x"], SimpleNamespace(), False)
+        zones = await get_zones(["http://x"], _make_hass(), False)
     assert zones[0].name == "Home"
 
 
@@ -226,7 +236,7 @@ async def test_parse_serialize_roundtrip_preserves_extra_properties() -> None:
         "custom_components.polygonal_zones.utils.zones.load_data",
         new=AsyncMock(return_value=source),
     ):
-        first = await get_zones(["http://x"], SimpleNamespace(), False)
+        first = await get_zones(["http://x"], _make_hass(), False)
 
     serialized = zones_to_geojson(first)
 
@@ -234,7 +244,7 @@ async def test_parse_serialize_roundtrip_preserves_extra_properties() -> None:
         "custom_components.polygonal_zones.utils.zones.load_data",
         new=AsyncMock(return_value=serialized),
     ):
-        second = await get_zones(["http://x"], SimpleNamespace(), False)
+        second = await get_zones(["http://x"], _make_hass(), False)
 
     assert second[0].properties["description"] == "front door"
     assert second[0].properties["polygonal_zones_ext"] == {"color": "#f00"}
@@ -256,7 +266,7 @@ async def test_get_zones_rejects_future_schema_version() -> None:
         ),
         pytest.raises(UnsupportedSchemaVersion, match="schema_version=99"),
     ):
-        await get_zones(["http://x"], SimpleNamespace(), False)
+        await get_zones(["http://x"], _make_hass(), False)
 
 
 # ---------- Structural validation: _parse_feature via _load_zones_from_uri ----------
@@ -271,7 +281,7 @@ async def test_get_zones_rejects_top_level_not_object() -> None:
         ),
         pytest.raises(ZoneFileCorrupt, match="top-level payload is not an object"),
     ):
-        await get_zones(["http://x"], SimpleNamespace(), False)
+        await get_zones(["http://x"], _make_hass(), False)
 
 
 async def test_get_zones_rejects_non_json_body() -> None:
@@ -282,7 +292,7 @@ async def test_get_zones_rejects_non_json_body() -> None:
         ),
         pytest.raises(ZoneFileCorrupt, match="not valid JSON"),
     ):
-        await get_zones(["http://x"], SimpleNamespace(), False)
+        await get_zones(["http://x"], _make_hass(), False)
 
 
 async def test_get_zones_rejects_missing_features_list() -> None:
@@ -294,7 +304,7 @@ async def test_get_zones_rejects_missing_features_list() -> None:
         ),
         pytest.raises(ZoneFileCorrupt, match="'features' is missing"),
     ):
-        await get_zones(["http://x"], SimpleNamespace(), False)
+        await get_zones(["http://x"], _make_hass(), False)
 
 
 async def test_get_zones_rejects_feature_missing_geometry() -> None:
@@ -307,7 +317,7 @@ async def test_get_zones_rejects_feature_missing_geometry() -> None:
         ),
         pytest.raises(ZoneFileCorrupt, match="no 'geometry' object"),
     ):
-        await get_zones(["http://x"], SimpleNamespace(), False)
+        await get_zones(["http://x"], _make_hass(), False)
 
 
 async def test_get_zones_rejects_feature_blank_name() -> None:
@@ -324,7 +334,7 @@ async def test_get_zones_rejects_feature_blank_name() -> None:
         ),
         pytest.raises(ZoneFileCorrupt, match=r"properties\.name"),
     ):
-        await get_zones(["http://x"], SimpleNamespace(), False)
+        await get_zones(["http://x"], _make_hass(), False)
 
 
 async def test_get_zones_rejects_feature_unparseable_priority() -> None:
@@ -341,7 +351,7 @@ async def test_get_zones_rejects_feature_unparseable_priority() -> None:
         ),
         pytest.raises(ZoneFileCorrupt, match="non-integer priority"),
     ):
-        await get_zones(["http://x"], SimpleNamespace(), False)
+        await get_zones(["http://x"], _make_hass(), False)
 
 
 # ---------- Per-URI partial success via load_zones ----------
@@ -361,7 +371,7 @@ async def test_load_zones_partial_success_keeps_successful_uris() -> None:
         "custom_components.polygonal_zones.utils.zones.load_data",
         side_effect=fake_load,
     ):
-        result = await load_zones(["http://good", "http://bad"], SimpleNamespace(), False)
+        result = await load_zones(["http://good", "http://bad"], _make_hass(), False)
 
     assert [z.name for z in result.zones] == ["Home"]
     assert len(result.failures) == 1
@@ -380,7 +390,7 @@ async def test_load_zones_all_fail_returns_empty_with_failures() -> None:
         "custom_components.polygonal_zones.utils.zones.load_data",
         side_effect=fake_load,
     ):
-        result = await load_zones(["http://a", "http://b"], SimpleNamespace(), False)
+        result = await load_zones(["http://a", "http://b"], _make_hass(), False)
 
     assert result.zones == []
     assert {uri for uri, _ in result.failures} == {"http://a", "http://b"}
@@ -399,7 +409,7 @@ async def test_get_zones_raises_when_all_uris_fail() -> None:
         ),
         pytest.raises(ZoneFileCorrupt, match="All 2 zone URIs failed"),
     ):
-        await get_zones(["http://a", "http://b"], SimpleNamespace(), False)
+        await get_zones(["http://a", "http://b"], _make_hass(), False)
 
 
 async def test_load_zones_unsupported_schema_propagates_as_hard_error() -> None:
@@ -418,4 +428,4 @@ async def test_load_zones_unsupported_schema_propagates_as_hard_error() -> None:
         ),
         pytest.raises(UnsupportedSchemaVersion),
     ):
-        await load_zones(["http://x"], SimpleNamespace(), False)
+        await load_zones(["http://x"], _make_hass(), False)


### PR DESCRIPTION
Panel P1 async/perf (sre + data-engineer).

## Changes
- **Executor offload** (`utils/zones.py`): split fetch (async, on-loop) from parse (CPU-only). `json.loads` + shapely geometry construction now run via `hass.async_add_executor_job` so a large `zones.json` doesn't block the event loop on every reload.
- **Read-time caps** (`utils/zones.py`): enforce feature-count + total-vertex limits on the load path — a remote/file producer isn't bound by the mutation-service validator.
- **Shared limits** (new `utils/limits.py`): single source of truth for the caps + vertex counter, imported by both the read path and `services/helpers.py`.

## Verified (Python 3.14.6 + HA 2026.6.4)
259 pass · 98.53% coverage · mypy + ruff clean. Dual-reviewed (Claude + codex), no findings.

> Deferred: single-session aiohttp reuse (changes load_data's shared contract; pure socket micro-opt).