### PR TITLE
Onboarding copy: lead the LAN/private-URL case with the fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Copy `custom_components/polygonal_zones/` into the `custom_components/` director
 1. **Add the integration**: Settings → Devices & Services → Add Integration → search "Polygonal Zones".
 2. **Fill in the form**:
    - **URLs of GeoJSON files**: one or more `https://…/zones.json` URLs, or relative paths under `/config` (e.g. `polygonal_zones/my_zones.json`). Leave empty if you want a blank file created for you (toggle **Download the GeoJSON files** below).
+     - 💡 **Using the companion add-on, or any URL on your LAN?** A local address like `http://192.168.x.x:8000/zones.json` is private and is **blocked by default** (SSRF protection). Enable **Allow private-network URLs (LAN)** in the same form to permit it — or place the file under `/config` and reference the path instead. This is the most common first-run snag.
    - **Entities**: the `device_tracker.*` entities whose location you want to evaluate against the zones.
    - **Prioritize order of zone files** _(advanced)_: when one position falls inside zones from more than one file, prefer the earlier file in the list.
    - **Download the GeoJSON files** _(advanced)_: download / merge the source URLs into a single local file under `<config>/polygonal_zones/<entry_id>.json`. **Required if you want to mutate zones from automations** via the action services below.

--- a/custom_components/polygonal_zones/strings.json
+++ b/custom_components/polygonal_zones/strings.json
@@ -18,7 +18,7 @@
           "download_zones": "Use a local GeoJSON file to store the zones in. This will load the above defined files into a single file. The entities will only use this single file to retrieve the zones from. If no GeoJSON files are defined we will create an empty GeoJSON file.",
           "registered_entities": "Select the entities that you want to track in the zones.",
           "expose_coordinates": "When enabled, the mirror entity writes latitude, longitude, and gps_accuracy to its attributes on every update — Home Assistant's recorder then persists a full location history. Disable to publish only the zone name (privacy-first). New installs default to off.",
-          "allow_private_urls": "⚠️ Accept zone_urls that resolve to RFC-1918 private addresses (e.g. 192.168.x.x, 10.x.x.x, fd00::/8). Needed when the zone source lives on your LAN — typically the companion editor add-on. Loopback (127.0.0.1 / ::1), link-local (169.254.x, cloud metadata), multicast, and reserved ranges stay blocked regardless. Leave off unless you know you need it."
+          "allow_private_urls": "Turn this on only if your zone source is on your local network — e.g. the companion editor add-on at http://192.168.x.x:8000/zones.json. Public https:// URLs and files in /config work without it. Loopback, link-local, and cloud-metadata addresses stay blocked either way."
         }
       },
       "reconfigure": {
@@ -38,7 +38,7 @@
           "download_zones": "Use a local GeoJSON file to store the zones in. This will load the above defined files into a single file. The entities will only use this single file to retrieve the zones from. If no GeoJSON files are defined we will create an empty GeoJSON file.",
           "registered_entities": "Select the entities that you want to track in the zones.",
           "expose_coordinates": "When enabled, the mirror entity writes latitude, longitude, and gps_accuracy to its attributes on every update — Home Assistant's recorder then persists a full location history. Disable to publish only the zone name (privacy-first). New installs default to off.",
-          "allow_private_urls": "⚠️ Accept zone_urls that resolve to RFC-1918 private addresses (e.g. 192.168.x.x, 10.x.x.x, fd00::/8). Needed when the zone source lives on your LAN — typically the companion editor add-on. Loopback (127.0.0.1 / ::1), link-local (169.254.x, cloud metadata), multicast, and reserved ranges stay blocked regardless. Leave off unless you know you need it."
+          "allow_private_urls": "Turn this on only if your zone source is on your local network — e.g. the companion editor add-on at http://192.168.x.x:8000/zones.json. Public https:// URLs and files in /config work without it. Loopback, link-local, and cloud-metadata addresses stay blocked either way."
         }
       }
     },
@@ -65,7 +65,7 @@
           "zone_urls": "Enter the URLs of the GeoJSON files that contain the zones you want to track. This supports both websites and files in the /config directory.",
           "prioritize_zone_files": "If you want to prioritize the order of the zone files, enable this option. This means that if a tracker is in multiple zones it will only consider those with the lowest priority.",
           "expose_coordinates": "When enabled, the mirror entity writes latitude, longitude, and gps_accuracy to its attributes on every update — Home Assistant's recorder then persists a full location history. Disable to publish only the zone name (privacy-first).",
-          "allow_private_urls": "⚠️ Accept zone_urls that resolve to RFC-1918 private addresses (e.g. 192.168.x.x, 10.x.x.x, fd00::/8). Needed when the zone source lives on your LAN — typically the companion editor add-on. Loopback / link-local / multicast / metadata ranges stay blocked. Leave off unless you know you need it."
+          "allow_private_urls": "Turn this on only if your zone source is on your local network — e.g. the companion editor add-on at http://192.168.x.x:8000/zones.json. Public https:// URLs and files in /config work without it. Loopback, link-local, and cloud-metadata addresses stay blocked either way."
         }
       }
     },

--- a/custom_components/polygonal_zones/translations/en.json
+++ b/custom_components/polygonal_zones/translations/en.json
@@ -18,7 +18,7 @@
           "zone_urls": "URLs of GeoJSON files"
         },
         "data_description": {
-          "allow_private_urls": "⚠️ Accept zone_urls that resolve to RFC-1918 private addresses (e.g. 192.168.x.x, 10.x.x.x, fd00::/8). Needed when the zone source lives on your LAN — typically the companion editor add-on. Loopback (127.0.0.1 / ::1), link-local (169.254.x, cloud metadata), multicast, and reserved ranges stay blocked regardless. Leave off unless you know you need it.",
+          "allow_private_urls": "Turn this on only if your zone source is on your local network — e.g. the companion editor add-on at http://192.168.x.x:8000/zones.json. Public https:// URLs and files in /config work without it. Loopback, link-local, and cloud-metadata addresses stay blocked either way.",
           "download_zones": "Use a local GeoJSON file to store the zones in. This will load the above defined files into a single file. The entities will only use this single file to retrieve the zones from. If no GeoJSON files are defined we will create an empty GeoJSON file.",
           "expose_coordinates": "When enabled, the mirror entity writes latitude, longitude, and gps_accuracy to its attributes on every update — Home Assistant's recorder then persists a full location history. Disable to publish only the zone name (privacy-first). New installs default to off.",
           "prioritize_zone_files": "If you want to prioritize the order of the zone files, enable this option. This means that if a tracker is in multiple zones it will only consider those with the lowest priority.",
@@ -38,7 +38,7 @@
           "zone_urls": "URLs of GeoJSON files"
         },
         "data_description": {
-          "allow_private_urls": "⚠️ Accept zone_urls that resolve to RFC-1918 private addresses (e.g. 192.168.x.x, 10.x.x.x, fd00::/8). Needed when the zone source lives on your LAN — typically the companion editor add-on. Loopback (127.0.0.1 / ::1), link-local (169.254.x, cloud metadata), multicast, and reserved ranges stay blocked regardless. Leave off unless you know you need it.",
+          "allow_private_urls": "Turn this on only if your zone source is on your local network — e.g. the companion editor add-on at http://192.168.x.x:8000/zones.json. Public https:// URLs and files in /config work without it. Loopback, link-local, and cloud-metadata addresses stay blocked either way.",
           "download_zones": "Use a local GeoJSON file to store the zones in. This will load the above defined files into a single file. The entities will only use this single file to retrieve the zones from. If no GeoJSON files are defined we will create an empty GeoJSON file.",
           "expose_coordinates": "When enabled, the mirror entity writes latitude, longitude, and gps_accuracy to its attributes on every update — Home Assistant's recorder then persists a full location history. Disable to publish only the zone name (privacy-first). New installs default to off.",
           "prioritize_zone_files": "If you want to prioritize the order of the zone files, enable this option. This means that if a tracker is in multiple zones it will only consider those with the lowest priority.",
@@ -65,7 +65,7 @@
           "zone_urls": "URLs of GeoJSON files"
         },
         "data_description": {
-          "allow_private_urls": "⚠️ Accept zone_urls that resolve to RFC-1918 private addresses (e.g. 192.168.x.x, 10.x.x.x, fd00::/8). Needed when the zone source lives on your LAN — typically the companion editor add-on. Loopback / link-local / multicast / metadata ranges stay blocked. Leave off unless you know you need it.",
+          "allow_private_urls": "Turn this on only if your zone source is on your local network — e.g. the companion editor add-on at http://192.168.x.x:8000/zones.json. Public https:// URLs and files in /config work without it. Loopback, link-local, and cloud-metadata addresses stay blocked either way.",
           "expose_coordinates": "When enabled, the mirror entity writes latitude, longitude, and gps_accuracy to its attributes on every update — Home Assistant's recorder then persists a full location history. Disable to publish only the zone name (privacy-first).",
           "prioritize_zone_files": "If you want to prioritize the order of the zone files, enable this option. This means that if a tracker is in multiple zones it will only consider those with the lowest priority.",
           "zone_urls": "Enter the URLs of the GeoJSON files that contain the zones you want to track. This supports both websites and files in the /config directory."


### PR DESCRIPTION
Product-panel finding (PM + product-designer): the `allow_private_urls` help text opened with the SSRF security enumeration before telling a happy-path user (pointing at the companion add-on on their LAN) what to do — and the README buried the LAN guidance in Troubleshooting.

## Changes (copy only)
- **strings.json + translations/en.json**: rewrote the `allow_private_urls` description (all 3 steps) happy-path first — what to enable for a LAN/add-on URL, then the security note in one line.
- **README**: added an above-the-fold callout under the URLs field in *First-time setup* naming the **Allow private-network URLs (LAN)** toggle (the #1 first-run snag per the community thread).

No behaviour change. Dual-reviewed (Claude + codex), no findings.