### PR TITLE
download_zones: reconfigure-safe default + options escape hatch

### DIFF
--- a/custom_components/polygonal_zones/config_flow.py
+++ b/custom_components/polygonal_zones/config_flow.py
@@ -31,14 +31,23 @@ def build_create_flow(
 ) -> vol.Schema:
     """Create the schema for the configuration flow.
 
-    ``new_entry`` swaps the fallback for ``expose_coordinates`` between the
-    privacy-safe default (``False`` for new installs) and the back-compat
-    default (``True`` for existing entries being reconfigured that were
-    created before the option existed). Keys that are already present in
-    ``defaults`` always win over both fallbacks.
+    ``new_entry`` swaps the fallbacks for ``expose_coordinates`` and
+    ``download_zones`` between the new-install default and the back-compat
+    default for an existing entry created before the option existed:
+
+    - ``expose_coordinates``: ``False`` for new installs (privacy-safe),
+      ``True`` for reconfigured legacy entries.
+    - ``download_zones``: ``True`` for new installs (CRUD works out of the
+      box), ``False`` for reconfigured legacy entries — so opening the
+      reconfigure form on an old read-only entry and submitting without
+      touching the toggle does NOT silently convert it to a writable local
+      snapshot.
+
+    Keys already present in ``defaults`` always win over both fallbacks.
     """
     defaults = defaults or {}
     expose_fallback = not new_entry
+    download_fallback = new_entry
 
     return vol.Schema(
         {
@@ -61,7 +70,7 @@ def build_create_flow(
             ): selector.BooleanSelector(),
             vol.Optional(
                 "download_zones",
-                default=defaults.get("download_zones", True),
+                default=defaults.get("download_zones", download_fallback),
                 description={"advanced": True},
             ): selector.BooleanSelector(),
             vol.Optional(
@@ -86,6 +95,10 @@ def build_options_flow(
     This function differs from the config schema by not adding the options for the entities.
     Existing entries created before the ``expose_coordinates`` option existed keep
     their current behaviour (coordinates exposed) until the user opts out.
+
+    ``download_zones`` is exposed here too so it can be toggled after setup
+    without a full reconfigure. Its fallback is ``False`` so a legacy entry
+    that never stored the key stays read-only until the user opts in.
     """
     defaults = defaults or {}
     return vol.Schema(
@@ -99,6 +112,10 @@ def build_options_flow(
             vol.Required(
                 "prioritize_zone_files",
                 default=defaults.get("prioritize_zone_files", False),
+            ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
+            vol.Required(
+                "download_zones",
+                default=defaults.get("download_zones", False),
             ): selector.BooleanSelector(selector.BooleanSelectorConfig()),
             vol.Required(
                 "expose_coordinates",

--- a/custom_components/polygonal_zones/strings.json
+++ b/custom_components/polygonal_zones/strings.json
@@ -58,12 +58,14 @@
         "data": {
           "zone_urls": "URLs of GeoJSON files",
           "prioritize_zone_files": "Prioritize order of zone files",
+          "download_zones": "Download the GeoJSON files",
           "expose_coordinates": "Expose GPS coordinates as entity attributes",
           "allow_private_urls": "Allow private-network URLs (LAN)"
         },
         "data_description": {
           "zone_urls": "Enter the URLs of the GeoJSON files that contain the zones you want to track. This supports both websites and files in the /config directory.",
           "prioritize_zone_files": "If you want to prioritize the order of the zone files, enable this option. This means that if a tracker is in multiple zones it will only consider those with the lowest priority.",
+          "download_zones": "Use a local GeoJSON file to store the zones in. This will load the above defined files into a single file. The entities will only use this single file to retrieve the zones from. If no GeoJSON files are defined we will create an empty GeoJSON file.",
           "expose_coordinates": "When enabled, the mirror entity writes latitude, longitude, and gps_accuracy to its attributes on every update — Home Assistant's recorder then persists a full location history. Disable to publish only the zone name (privacy-first).",
           "allow_private_urls": "Turn this on only if your zone source is on your local network — e.g. the companion editor add-on at http://192.168.x.x:8000/zones.json. Public https:// URLs and files in /config work without it. Loopback, link-local, and cloud-metadata addresses stay blocked either way."
         }

--- a/custom_components/polygonal_zones/translations/en.json
+++ b/custom_components/polygonal_zones/translations/en.json
@@ -62,12 +62,14 @@
           "allow_private_urls": "Allow private-network URLs (LAN)",
           "expose_coordinates": "Expose GPS coordinates as entity attributes",
           "prioritize_zone_files": "Prioritize order of zone files",
+          "download_zones": "Download the GeoJSON files",
           "zone_urls": "URLs of GeoJSON files"
         },
         "data_description": {
           "allow_private_urls": "Turn this on only if your zone source is on your local network — e.g. the companion editor add-on at http://192.168.x.x:8000/zones.json. Public https:// URLs and files in /config work without it. Loopback, link-local, and cloud-metadata addresses stay blocked either way.",
           "expose_coordinates": "When enabled, the mirror entity writes latitude, longitude, and gps_accuracy to its attributes on every update — Home Assistant's recorder then persists a full location history. Disable to publish only the zone name (privacy-first).",
           "prioritize_zone_files": "If you want to prioritize the order of the zone files, enable this option. This means that if a tracker is in multiple zones it will only consider those with the lowest priority.",
+          "download_zones": "Use a local GeoJSON file to store the zones in. This will load the above defined files into a single file. The entities will only use this single file to retrieve the zones from. If no GeoJSON files are defined we will create an empty GeoJSON file.",
           "zone_urls": "Enter the URLs of the GeoJSON files that contain the zones you want to track. This supports both websites and files in the /config directory."
         },
         "description": "Update the zone sources and priority settings for this integration.",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -30,14 +30,33 @@ def test_build_create_flow_has_all_required_keys() -> None:
 
 def test_build_create_flow_download_zones_defaults_true_for_new_entries() -> None:
     """New installs default download_zones to True so mutation services work out of the box."""
-    schema = build_create_flow()
+    schema = build_create_flow(new_entry=True)
     download_key = next(k for k in schema.schema if str(k) == "download_zones")
     assert download_key.default() is True
+
+
+def test_build_create_flow_download_zones_defaults_false_on_reconfigure_legacy_entry() -> None:
+    """Reconfiguring a legacy entry that never stored download_zones must NOT silently
+    flip it to True — the fallback is False so submitting the form unchanged keeps the
+    entry read-only."""
+    schema = build_create_flow(new_entry=False)
+    download_key = next(k for k in schema.schema if str(k) == "download_zones")
+    assert download_key.default() is False
 
 
 def test_build_create_flow_preserves_existing_download_zones_false() -> None:
     """A reconfigure flow on an entry with download_zones=False preserves that choice."""
     schema = build_create_flow({"download_zones": False})
+    download_key = next(k for k in schema.schema if str(k) == "download_zones")
+    assert download_key.default() is False
+
+
+def test_build_options_flow_exposes_download_zones() -> None:
+    """The options flow now exposes download_zones as a post-setup escape hatch,
+    defaulting False for a legacy entry that never stored it."""
+    from custom_components.polygonal_zones.config_flow import build_options_flow
+
+    schema = build_options_flow()
     download_key = next(k for k in schema.schema if str(k) == "download_zones")
     assert download_key.default() is False
 


### PR DESCRIPTION
Backend-panel P0 (the safe half of the download_zones review).

## Problem
`download_zones` already defaults **True** for new installs (`config_flow.py:64`). But reconfiguring a **legacy** entry that never stored the key re-defaulted it to True — so opening the reconfigure form and submitting unchanged **silently converted a read-only entry to a writable local snapshot** and dropped live remote-URL syncing, with no way to undo via Options.

## Fix
- Mirror the existing `expose_coordinates` pattern: `download_fallback = new_entry` — defaults **True for new installs**, **False on reconfigure** of a legacy entry. Stored values always win.
- Expose `download_zones` in the **options flow** (default False for legacy) as a post-setup escape hatch; added its label/description to `strings.json` + `translations/en.json`.
- New tests: new-install→True, legacy-reconfigure→False, options exposure→False.

## Verified (Python 3.14.6 + HA 2026.6.4)
261 pass · 98.54% coverage · mypy + ruff + format clean.

## Deliberately NOT included
The other panel-P0 item — *move `sync_entities_after_write` outside the file lock* — is **held**: codex flagged that moving it out introduces a reload **ordering race** (overlapping mutations' post-lock reloads can finish out of order → stale cache). That's a genuine trade-off vs the backend panel's lock-amplification concern; awaiting a decision before implementing.